### PR TITLE
Add a note about non-renewable energy compensation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,30 @@ Wattson is a Python library for estimating cloud compute carbon emissions.
 
 It currently supports estimating emissions for a range of Amazon EC2 instances in a variety of regions.
 
+## Usage
+You can install this package with pip by running `pip install valohai-wattson`.
+
+If you are currently using AWS instances, you can calculate the carbon emissions for your instances using the following code:
+```
+from wattson import estiamte_carbon_emissions
+
+training_emissions = estimate_carbon_emissions(
+    instance_type='c4.2xlarge',
+    region='us-east-1',
+    hours=1,
+    load_percentage=0.5,
+)
+```
+The returned value will be of the type `wattson.EmissionsEstimation` and have the following information:
+- `data_license`: The license of the data used to estimate the emissions.
+- `region`: The region the original computation was performed in.
+- `instance_type`: The instance type of the original computation.
+- `avg_load`: The average CPU load during the original computation (defaults to 50% if not specified).
+- `scope_2_co2eq`: The estimated CO2 emissions for the electricity used in the original computation.
+- `scope_3_co2eq`: The estimated CO2 emissions for manufacturing of the device used in the original computation, assuming a 4-year usage.
+- `compensated`: Were any of the emissions of the original computation compensated using e.g. carbon emissions compensation or renewable energy credits.
+- `details`: Any additional details about e.g. the compensation methodology.
+
 ## Acknowledgements
 
 This project uses the [EC2 Carbon Emissions Dataset by Teads Engineering](https://docs.google.com/spreadsheets/d/1DqYgQnEDLQVQm5acMAhLgHLD8xXCG9BIrk-_Nv6jF3k/).

--- a/wattson/consts.py
+++ b/wattson/consts.py
@@ -1,0 +1,7 @@
+RENEWABLE_ENERGY_CREDITS_COMPENSATED_REGIONS = (
+    "ca-central-1",  # Canada (Central)
+    "eu-central-1",  # Europe (Frankfurt)
+    "eu-west-1",  # Europe (Ireland)
+    "us-gov-west-2",  # U.S. Government (U.S. West)
+    "us-west-2",  # U.S. West (Oregon)
+)

--- a/wattson/estimator.py
+++ b/wattson/estimator.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+from wattson.consts import RENEWABLE_ENERGY_CREDITS_COMPENSATED_REGIONS
 from wattson.data import data_license, instance_data, region_data
 from wattson.interpolation import interpolate_from_table
 from wattson.types import EmissionsEstimation, InstanceData, RegionData
@@ -56,7 +57,6 @@ def estimate_carbon_emissions(
     :param load_percentage: The instance average CPU load % 0-100.
     :return: The estimated carbon emissions in eCO2eq.
     """
-
     instance = instance_data.get(instance_type)
     region_details = region_data.get(region)
 
@@ -72,6 +72,15 @@ def estimate_carbon_emissions(
     if hours < 0:
         raise ValueError(f"Hours {hours} must be positive.")
 
+    compensated = False
+    details = ""
+    if region in RENEWABLE_ENERGY_CREDITS_COMPENSATED_REGIONS:
+        compensated = True
+        details = (
+            "The non-renewable energy used in this AWS region has been compensated by renewable energy credits. "  # noqa: E501
+            "See https://sustainability.aboutamazon.com/environment/the-cloud?energyType=true "  # noqa: E501
+        )
+
     return EmissionsEstimation(
         region=region,
         hours=hours,
@@ -85,4 +94,6 @@ def estimate_carbon_emissions(
         ),
         scope_3_co2eq=calculate_scope_3(instance=instance, hours=hours),
         data_license=data_license,
+        details=details,
+        compensated=compensated,
     )

--- a/wattson/types.py
+++ b/wattson/types.py
@@ -11,6 +11,8 @@ class EmissionsEstimation:
     instance_type: str
     scope_2_co2eq: float
     scope_3_co2eq: float
+    compensated: bool
+    details: str
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
As per [AWS](https://sustainability.aboutamazon.com/environment/the-cloud?energyType=true):
```
AWS purchases and retires environmental attributes, like Renewable Energy Credits and Guarantees of Origin, to cover the non-renewable energy we use in these regions:
U.S. West (Oregon)
GovCloud (U.S. West)
Europe (Frankfurt)
Canada (Central)
Europe (Ireland)
```
The notes field could in the future also contain other info such as an explanation of carbon compensation on GCP or some kind of methodology notes.